### PR TITLE
add strip mode for compact panel layout

### DIFF
--- a/bitforge-dockermetrics-panel/package.json
+++ b/bitforge-dockermetrics-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-metrics-panel",
-  "version": "1.2.16",
+  "version": "1.2.20",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",

--- a/bitforge-dockermetrics-panel/src/module.ts
+++ b/bitforge-dockermetrics-panel/src/module.ts
@@ -6,6 +6,7 @@ import { ContainerSelectorEditor } from './components/ContainerSelectorEditor';
 import { MetricSelectorEditor } from './components/MetricSelectorEditor';
 
 export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOptions((builder) => {
+  console.warn('[DockerMetrics:module] setPanelOptions called, registering options...');
   return builder
     .addCustomEditor({
       id: 'hostManager',
@@ -39,6 +40,17 @@ export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOption
       category: ['Display'],
       editor: MetricSelectorEditor,
       defaultValue: DEFAULT_METRICS,
+    })
+    .addBooleanSwitch({
+      path: 'stripMode',
+      name: 'Strip Mode',
+      description: 'Hide host headers and show all containers in a single grid (useful for small panels)',
+      defaultValue: false,
+      category: ['Layout'],
+      showIf: (config) => {
+        console.warn('[DockerMetrics:module] stripMode showIf called, config:', config);
+        return true;
+      },
     })
     .addNumberInput({
       path: 'containersPerRow',

--- a/bitforge-dockermetrics-panel/src/types.ts
+++ b/bitforge-dockermetrics-panel/src/types.ts
@@ -9,6 +9,7 @@ export interface SimpleOptions {
   metricsPerRow: number;
   enableContainerControls: boolean;
   refreshInterval: number; // Refresh interval in seconds
+  stripMode: boolean;               // Strip mode - hide host headers, show all containers in a single grid
 }
 
 // Progressive fetch stages

--- a/bitforge-dockermetrics-panel/src/version.ts
+++ b/bitforge-dockermetrics-panel/src/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-updated by release.sh
-export const PLUGIN_VERSION = '1.2.16';
+export const PLUGIN_VERSION = '1.2.20';


### PR DESCRIPTION
Strip mode hides host headers and displays all containers from all hosts in a single grid, useful for small panels or when host grouping is not needed.

- Add stripMode option to SimpleOptions interface
- Add Strip Mode toggle in Layout panel options
- Implement strip mode rendering in SimplePanel
- Bump version to 1.2.20

Closes #1