### PR TITLE
Remove obsolete refreshInterval panel option

### DIFF
--- a/bitforge-dockermetrics-panel/src/module.ts
+++ b/bitforge-dockermetrics-panel/src/module.ts
@@ -36,18 +36,6 @@ export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOption
         integer: true,
       },
     })
-    .addNumberInput({
-      path: 'refreshInterval',
-      name: 'Refresh Interval',
-      description: 'How often to fetch new metrics (in seconds)',
-      defaultValue: 10,
-      category: ['Data'],
-      settings: {
-        min: 1,
-        max: 300,
-        integer: true,
-      },
-    })
     .addBooleanSwitch({
       path: 'enableControls',
       name: 'Enable Container Controls',

--- a/bitforge-dockermetrics-panel/src/types.ts
+++ b/bitforge-dockermetrics-panel/src/types.ts
@@ -74,10 +74,10 @@ export function getStateDisplay(state: ContainerState): { label: string; color: 
 }
 
 // Panel options - layout only (filtering moved to data source query)
+// Note: Data refresh is handled by Grafana's dashboard-level refresh interval
 export interface SimpleOptions {
   containersPerRow: number;
   metricsPerRow: number;
-  refreshInterval: number; // Refresh interval in seconds
   stripMode: boolean;      // Strip mode - hide host headers, show all containers in a single grid
   // Container control options
   enableControls: boolean;

--- a/docs/architecture/components/grafana-panel.md
+++ b/docs/architecture/components/grafana-panel.md
@@ -79,15 +79,14 @@ The Bitforge Docker Metrics Panel is a React-based Grafana panel plugin that vis
 
 ```typescript
 interface SimpleOptions {
-  hosts: HostConfig[];           // Agent configurations
-  selectedContainerIds: string[];// Container filter
-  containerFilterMode: 'all' | 'whitelist' | 'blacklist';
-  refreshInterval: number;       // 1-300 seconds
-  containersPerRow: number;      // Layout control
-  metricsPerRow: number;
-  selectedMetrics: string[];     // Which metrics to show
-  showControls: boolean;         // Enable action buttons
+  containersPerRow: number;      // Layout control (0 = auto)
+  metricsPerRow: number;         // Layout control (0 = auto)
+  stripMode: boolean;            // Hide host headers, single grid layout
+  enableControls: boolean;       // Enable action buttons
+  allowedActions: ControlAction[];  // Which actions to show
+  confirmDangerousActions: boolean; // Confirm stop/restart
 }
+// Note: Data refresh is handled by Grafana's dashboard-level refresh interval
 
 interface ContainerMetrics {
   id: string;


### PR DESCRIPTION
## Summary
- Removed the unused `refreshInterval` panel option from visualization settings
- The panel now uses Grafana's native data source query system where refresh is controlled by the dashboard-level refresh interval (top-right dropdown)
- Updated documentation to reflect current `SimpleOptions` interface

## Test plan
- [ ] Verify panel builds without errors
- [ ] Confirm no "Refresh Interval" option appears in panel settings
- [ ] Verify dashboard refresh interval controls data updates as expected

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)